### PR TITLE
Potential fix for code scanning alert no. 1: Application backup allowed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Potential fix for [https://github.com/ThiagoRech1997/ToneForge/security/code-scanning/1](https://github.com/ThiagoRech1997/ToneForge/security/code-scanning/1)

To fix the issue, the `android:allowBackup` attribute in the `<application>` element should be set to `false`. This will disable automatic backups for the application, ensuring that sensitive data cannot be extracted through backups. The change should be made in the `app/src/main/AndroidManifest.xml` file, specifically on line 36 where `android:allowBackup` is currently set to `true`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
