### PR TITLE
refactor: restrict file provider scope

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,8 +79,7 @@
             android:name="androidx.core.content.FileProvider"
             android:authorities="com.thiagofernendorech.toneforge.fileprovider"
             android:exported="false"
-            android:grantUriPermissions="true"
-            android:requestLegacyExternalStorage="true">
+            android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />

--- a/app/src/main/java/com/thiagofernendorech/toneforge/infrastructure/loops/LoopExportManager.java
+++ b/app/src/main/java/com/thiagofernendorech/toneforge/infrastructure/loops/LoopExportManager.java
@@ -66,8 +66,12 @@ public class LoopExportManager {
                     ? customName.trim() 
                     : "loop_" + new Date().getTime();
                 exportedFileName = baseName + format.getExtension();
-                
-                File outFile = new File(context.getFilesDir(), exportedFileName);
+
+                File loopsDir = new File(context.getFilesDir(), "loops");
+                if (!loopsDir.exists()) {
+                    loopsDir.mkdirs();
+                }
+                File outFile = new File(loopsDir, exportedFileName);
                 
                 // Exportar baseado no formato
                 switch (format) {

--- a/app/src/main/java/com/thiagofernendorech/toneforge/infrastructure/loops/LoopExportUtil.java
+++ b/app/src/main/java/com/thiagofernendorech/toneforge/infrastructure/loops/LoopExportUtil.java
@@ -41,7 +41,11 @@ public class LoopExportUtil {
                 
                 int sampleRate = 48000; // fixo por enquanto
                 String fileName = "loop_" + new Date().getTime() + ".wav";
-                File outFile = new File(context.getFilesDir(), fileName);
+                File loopsDir = new File(context.getFilesDir(), "loops");
+                if (!loopsDir.exists()) {
+                    loopsDir.mkdirs();
+                }
+                File outFile = new File(loopsDir, fileName);
                 LogManager.verbose("LoopExportUtil", "Salvando WAV em: " + outFile.getAbsolutePath());
                 
                 writeWavFile(mix, sampleRate, outFile);
@@ -52,7 +56,7 @@ public class LoopExportUtil {
                     
                     // Listar todos os arquivos na pasta para debug (apenas verbose)
                     if (LogManager.getInstance(context).isVerboseLogging()) {
-                        File filesDir = context.getFilesDir();
+                        File filesDir = new File(context.getFilesDir(), "loops");
                         File[] allFiles = filesDir.listFiles();
                         LogManager.verbose("LoopExportUtil", "Arquivos na pasta após salvar: " + (allFiles != null ? allFiles.length : 0));
                         if (allFiles != null) {

--- a/app/src/main/java/com/thiagofernendorech/toneforge/infrastructure/loops/LoopLibraryManager.java
+++ b/app/src/main/java/com/thiagofernendorech/toneforge/infrastructure/loops/LoopLibraryManager.java
@@ -72,9 +72,12 @@ public class LoopLibraryManager {
         @Override
         protected List<LoopInfo> doInBackground(Void... voids) {
             List<LoopInfo> loops = new ArrayList<>();
-            File filesDir = context.getFilesDir();
+            File filesDir = new File(context.getFilesDir(), "loops");
+            if (!filesDir.exists()) {
+                filesDir.mkdirs();
+            }
             android.util.Log.d("LoopLibraryManager", "Procurando arquivos em: " + filesDir.getAbsolutePath());
-            
+
             File[] files = filesDir.listFiles();
             android.util.Log.d("LoopLibraryManager", "Total de arquivos encontrados: " + (files != null ? files.length : 0));
             
@@ -145,7 +148,7 @@ public class LoopLibraryManager {
         @Override
         protected Boolean doInBackground(Void... voids) {
             try {
-                File file = new File(context.getFilesDir(), fileName);
+                File file = new File(new File(context.getFilesDir(), "loops"), fileName);
                 return file.delete();
             } catch (Exception e) {
                 e.printStackTrace();
@@ -175,20 +178,20 @@ public class LoopLibraryManager {
         @Override
         protected Boolean doInBackground(Void... voids) {
             try {
-                File oldFile = new File(context.getFilesDir(), oldFileName);
+                File oldFile = new File(new File(context.getFilesDir(), "loops"), oldFileName);
                 if (!oldFile.exists()) {
                     return false;
                 }
                 
                 // Criar novo nome de arquivo baseado no display name
                 String newFileName = createFileNameFromDisplayName(newDisplayName);
-                File newFile = new File(context.getFilesDir(), newFileName);
+                File newFile = new File(new File(context.getFilesDir(), "loops"), newFileName);
                 
                 // Se o arquivo já existe, adicionar sufixo
                 int counter = 1;
                 while (newFile.exists()) {
                     newFileName = createFileNameFromDisplayName(newDisplayName + " (" + counter + ")");
-                    newFile = new File(context.getFilesDir(), newFileName);
+                    newFile = new File(new File(context.getFilesDir(), "loops"), newFileName);
                     counter++;
                 }
                 

--- a/app/src/main/java/com/thiagofernendorech/toneforge/infrastructure/loops/LoopLoadUtil.java
+++ b/app/src/main/java/com/thiagofernendorech/toneforge/infrastructure/loops/LoopLoadUtil.java
@@ -39,9 +39,12 @@ public class LoopLoadUtil {
         @Override
         protected List<String> doInBackground(Void... voids) {
             List<String> fileNames = new ArrayList<>();
-            File filesDir = context.getFilesDir();
+            File filesDir = new File(context.getFilesDir(), "loops");
+            if (!filesDir.exists()) {
+                filesDir.mkdirs();
+            }
             LogManager.verbose("LoopLoadUtil", "Procurando arquivos em: " + filesDir.getAbsolutePath());
-            
+
             File[] files = filesDir.listFiles();
             LogManager.verbose("LoopLoadUtil", "Total de arquivos encontrados: " + (files != null ? files.length : 0));
             
@@ -79,7 +82,7 @@ public class LoopLoadUtil {
         @Override
         protected Boolean doInBackground(Void... voids) {
             try {
-                File file = new File(context.getFilesDir(), fileName);
+                File file = new File(new File(context.getFilesDir(), "loops"), fileName);
                 if (!file.exists()) {
                     return false;
                 }

--- a/app/src/main/java/com/thiagofernendorech/toneforge/infrastructure/loops/LoopShareUtil.java
+++ b/app/src/main/java/com/thiagofernendorech/toneforge/infrastructure/loops/LoopShareUtil.java
@@ -10,7 +10,8 @@ public class LoopShareUtil {
     
     public static void shareLoop(Context context, String fileName) {
         try {
-            File file = new File(context.getFilesDir(), fileName);
+            File loopsDir = new File(context.getFilesDir(), "loops");
+            File file = new File(loopsDir, fileName);
             if (!file.exists()) {
                 android.widget.Toast.makeText(context, "Arquivo não encontrado", android.widget.Toast.LENGTH_SHORT).show();
                 return;
@@ -60,12 +61,13 @@ public class LoopShareUtil {
     public static void shareLoopFromLibrary(Context context, String fileName) {
         try {
             // Tentar diferentes localizações do arquivo
-            File file = new File(context.getFilesDir(), fileName);
+            File loopsDir = new File(context.getFilesDir(), "loops");
+            File file = new File(loopsDir, fileName);
             if (!file.exists()) {
-                file = new File(context.getCacheDir(), fileName);
+                file = new File(new File(context.getCacheDir(), "loops"), fileName);
             }
             if (!file.exists()) {
-                file = new File(context.getExternalFilesDir(null), fileName);
+                file = new File(new File(context.getExternalFilesDir(null), "loops"), fileName);
             }
             
             if (!file.exists()) {

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <files-path name="loops" path="." />
-    <cache-path name="cache" path="." />
-    <external-files-path name="external_files" path="." />
-</paths> 
+    <files-path name="loops" path="loops/" />
+    <cache-path name="cache" path="loops/" />
+    <external-files-path name="external_files" path="loops/" />
+</paths>


### PR DESCRIPTION
## Summary
- limit `FileProvider` paths to loops subdirectories
- drop `requestLegacyExternalStorage` from manifest
- update loop utilities to use new `loops` folder

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d97281988324b93a887961410efe