### PR TITLE
Validate buffer lengths before native processing

### DIFF
--- a/app/src/main/cpp/audio_engine.cpp
+++ b/app/src/main/cpp/audio_engine.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <mutex>
 #include <string>
+#include <algorithm>
 
 // Mutexes para proteção thread-safe
 static std::mutex audioEngineMutex;
@@ -956,12 +957,24 @@ void downsample(const float* input, float* output, int numSamples) {
     }
 }
 
-void processBuffer(float* input, float* output, int numSamples) {
-    // Verificação rápida para evitar processamento desnecessário
+void processBuffer(float* input, float* output, int numSamples, int inputLength, int outputLength) {
+    // Verificar parâmetros básicos
     if (input == nullptr || output == nullptr || numSamples <= 0) {
-        printf("processBuffer: Parâmetros inválidos - input: %p, output: %p, numSamples: %d\n", 
+        printf("processBuffer: Parâmetros inválidos - input: %p, output: %p, numSamples: %d\n",
                input, output, numSamples);
         return;
+    }
+
+    // Ajustar numSamples se os buffers forem menores que o necessário
+    if (inputLength < numSamples || outputLength < numSamples) {
+        int available = std::min(inputLength, outputLength);
+        if (available <= 0) {
+            printf("processBuffer: Buffers insuficientes - inputLen: %d, outputLen: %d\n", inputLength, outputLength);
+            return;
+        }
+        printf("processBuffer: Ajustando numSamples de %d para %d devido ao tamanho dos buffers\n",
+               numSamples, available);
+        numSamples = available;
     }
     
     // Verificar se há efeitos ativos para evitar processamento desnecessário

--- a/app/src/main/cpp/audio_engine.h
+++ b/app/src/main/cpp/audio_engine.h
@@ -10,7 +10,7 @@ extern "C" {
     
     // Processamento de áudio
     float processSample(float input);
-    void processBuffer(float* input, float* output, int numSamples);
+    void processBuffer(float* input, float* output, int numSamples, int inputLength, int outputLength);
     
     // Inicialização e limpeza
     void initAudioEngine();

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -1,6 +1,7 @@
 #include <jni.h>
 #include <string>
 #include <vector>
+#include <algorithm>
 #include "audio_engine.h"
 
 extern "C" JNIEXPORT jstring JNICALL
@@ -62,12 +63,23 @@ Java_com_thiagofernendorech_toneforge_MainActivity_processBuffer(
         jfloatArray input,
         jfloatArray output,
         jint numSamples) {
-    
+
+    jsize inputLen = env->GetArrayLength(input);
+    jsize outputLen = env->GetArrayLength(output);
+
+    int available = numSamples;
+    if (inputLen < numSamples || outputLen < numSamples) {
+        available = std::min(static_cast<int>(inputLen), static_cast<int>(outputLen));
+        if (available <= 0) {
+            return;
+        }
+    }
+
     jfloat* inputPtr = env->GetFloatArrayElements(input, nullptr);
     jfloat* outputPtr = env->GetFloatArrayElements(output, nullptr);
-    
-    processBuffer(inputPtr, outputPtr, numSamples);
-    
+
+    processBuffer(inputPtr, outputPtr, available, static_cast<int>(inputLen), static_cast<int>(outputLen));
+
     env->ReleaseFloatArrayElements(input, inputPtr, JNI_ABORT);
     env->ReleaseFloatArrayElements(output, outputPtr, 0);
 }
@@ -131,11 +143,22 @@ Java_com_thiagofernendorech_toneforge_AudioEngine_setReverbLevel(JNIEnv* env, jc
 // Processamento de áudio para AudioEngine
 extern "C" JNIEXPORT void JNICALL
 Java_com_thiagofernendorech_toneforge_AudioEngine_processBuffer(JNIEnv* env, jclass clazz, jfloatArray input, jfloatArray output, jint numSamples) {
+    jsize inputLen = env->GetArrayLength(input);
+    jsize outputLen = env->GetArrayLength(output);
+
+    int available = numSamples;
+    if (inputLen < numSamples || outputLen < numSamples) {
+        available = std::min(static_cast<int>(inputLen), static_cast<int>(outputLen));
+        if (available <= 0) {
+            return;
+        }
+    }
+
     jfloat* inputPtr = env->GetFloatArrayElements(input, nullptr);
     jfloat* outputPtr = env->GetFloatArrayElements(output, nullptr);
-    
-    processBuffer(inputPtr, outputPtr, numSamples);
-    
+
+    processBuffer(inputPtr, outputPtr, available, static_cast<int>(inputLen), static_cast<int>(outputLen));
+
     env->ReleaseFloatArrayElements(input, inputPtr, JNI_ABORT);
     env->ReleaseFloatArrayElements(output, outputPtr, 0);
 }


### PR DESCRIPTION
## Summary
- guard processBuffer calls by checking input and output array lengths in JNI
- add buffer length parameters to native processBuffer and adjust numSamples when too large
- ensure native code respects actual buffer capacities during audio processing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d9adf49483249a5bcf6c090d4340